### PR TITLE
fix ordering of the binding args

### DIFF
--- a/falkon-engine-android-sqlite/src/main/kotlin/com/jayrave/falkon/engine/android/sqlite/CompiledQuery.kt
+++ b/falkon-engine-android-sqlite/src/main/kotlin/com/jayrave/falkon/engine/android/sqlite/CompiledQuery.kt
@@ -25,7 +25,14 @@ internal class CompiledQuery(override val sql: String, private val database: Sup
     override fun execute(): Source {
         throwIfClosed()
         return CursorBackedSource(database.query(
-                SimpleSQLiteQuery(sql, bindArgs.values.toTypedArray())
+                SimpleSQLiteQuery(
+                        sql,
+                        Array<Any?>(bindArgs.size) { null }.also { arr ->
+                            bindArgs.forEach { (index, value) ->
+                                arr[index - 1] = value
+                            }
+                        }
+                )
         ))
     }
 


### PR DESCRIPTION
We were doing `bindArgs.values.toTypedArray()`where `bindArgs` was `HashMap`. Since `HashMap` does not guarantee ordering, doing `values.toTypedArray` was resulting in inconsistent/wrong ordering.

For example, given this query: `SELECT COUNT(*) AS count FROM users WHERE (users.column1 = ? AND users.column2 = ? AND users.column3 = ?)` and we want to bind column1 = 1, column2 = 2 and column3 =3
Since the ordering is not guaranteed, if the args map has the entires in this order:
```
1 -> 1
3 -> 3
2 -> 2
```
It would bind `3` to column `2` and `2` to column `3`, which is not correct.

FIX: Manually creating the array and putting them in their index
